### PR TITLE
added --cors option to webapp to enable Cross-Origin Resource Sharing

### DIFF
--- a/bin/rock-webapp
+++ b/bin/rock-webapp
@@ -9,6 +9,8 @@ require 'orocos/webapp'
 thin_host = '0.0.0.0'
 thin_port = 9292
 name_server_host = 'localhost'
+cors_hosts = []
+
 options = OptionParser.new do |opt|
     opt.on('--host host', String, 'the host of the name server that should be contacted (default to localhost)') do |host|
         name_server_host = host
@@ -19,16 +21,30 @@ options = OptionParser.new do |opt|
     opt.on('--port port', Integer, "the server's port (default to #{thin_port})") do |port|
         thin_port = port
     end
+    opt.on('--enable-cors hosts', Array, "enables Cross-Origin Resource Sharing for sites loaded from the parameter may include localhost host:port, file://. Also multiple values seperated by ','") do |host|
+        cors_hosts = host
+    end
 end
 options.parse ARGV
+
+class WebApp < Grape::API
+end
+if !cors_hosts.empty?
+    require 'rack/cors'
+    WebApp.use Rack::Cors do                                                                     
+        allow do
+            origins *cors_hosts
+            resource '*', headers: :any, methods: [:get, :post]
+        end                                                                               
+    end  
+end
 
 Orocos::CORBA.name_service.ip = name_server_host
 Orocos.initialize
 
 Faye::WebSocket.load_adapter('thin')
-
 thin = Rack::Handler.get('thin')
-app  = Orocos::WebApp::Root.new
+WebApp.mount Orocos::WebApp::Root
 EM.next_tick { Orocos::WebApp.install_event_loop }
-thin.run(app, Host: thin_host, Port: thin_port)
+thin.run(WebApp.new, Host: thin_host, Port: thin_port)
 


### PR DESCRIPTION
Makes it possible to use JavaScript to access ports when the html page is
not provided by rock-webapp (e.g. by file://)

Also tried environment variable instad of global, but thought it whould be better to hav a single way to enable it
