### PR TITLE
fixed option parsing (opt.on returned nil)

### DIFF
--- a/bin/rock-webapp
+++ b/bin/rock-webapp
@@ -10,13 +10,13 @@ thin_host = '0.0.0.0'
 thin_port = 9292
 name_server_host = 'localhost'
 options = OptionParser.new do |opt|
-    opt.on('--host', String, 'the host of the name server that should be contacted (default to localhost)') do |host|
+    opt.on('--host host', String, 'the host of the name server that should be contacted (default to localhost)') do |host|
         name_server_host = host
     end
-    opt.on('--bind', String, 'the host the server should bind to (default to 0.0.0.0)') do |host|
+    opt.on('--bind host', String, 'the host the server should bind to (default to 0.0.0.0)') do |host|
         thin_host = host
     end
-    opt.on('--port', Integer, "the server's port (default to #{thin_port})") do |port|
+    opt.on('--port port', Integer, "the server's port (default to #{thin_port})") do |port|
         thin_port = port
     end
 end


### PR DESCRIPTION
Setting paramaters in the command line returned a nil object in the option block, a paramater must be stated in the first argument, otherwise the option is treated as boolan option.
