### PR TITLE
TaskConfiguration: do not save metadata inside of config-hashes

### DIFF
--- a/lib/orocos/configurations.rb
+++ b/lib/orocos/configurations.rb
@@ -489,6 +489,12 @@ module Orocos
         def self.config_as_hash(task)
             current_config = Hash.new
             task.each_property do |prop|
+                # Make sure we dont extract metadata information, check here against the
+                # typename instead aainst the type, to prevent problem if the
+                # metadata support is not installed.
+                if prop.name == "metadata" and prop.orocos_type_name == "/metadata/Component"
+                    next 
+                end
                 current_config[prop.name] = typelib_to_yaml_value(prop.raw_read)
             end
             current_config


### PR DESCRIPTION
We added a early version of metadata in rock, metadata are represented as
propertys. Therefore the configurations include this. But the metadata
should not be handled throught the normal configuration handling.
Therefore ignoring them here.

This solves the issue that oroconc extracts the metadata information of
tasks
