### PR TITLE
Aync::OutputReader: fix reading from buffered connections

### DIFF
--- a/lib/orocos/async/ports.rb
+++ b/lib/orocos/async/ports.rb
@@ -8,6 +8,8 @@ module Orocos::Async::CORBA
         attr_reader :policy
         attr_reader :raw_last_sample
 
+        attr_reader :period
+
         # The event loop timer that is polling the connection
         attr_reader :poll_timer
 
@@ -20,6 +22,7 @@ module Orocos::Async::CORBA
             @port = port
             @raw_last_sample = nil
             @policy = reader.policy
+            @period = period
 
             timeout =
                 if reader.policy[:type] == :buffer
@@ -311,16 +314,8 @@ module Orocos::Async::CORBA
             on_event :raw_data,&block
         end
 
-        def period
-            if @options.has_key?(:period)
-                @options[:period]
-            else
-                OutputReader.default_period
-            end
-        end
-
         def period=(value)
-            @options[:period] = value
+            @period = value
             @global_reader.period = value if @global_reader.respond_to?(:period=)
         end
 

--- a/test/async/test_ports.rb
+++ b/test/async/test_ports.rb
@@ -124,5 +124,23 @@ describe Orocos::Async::CORBA::OutputReader do
                 end
             end
         end
+
+        it "should read all data from a buffered connection even if the period of the reader is too large" do 
+            Orocos.run('simple_source') do
+                data = []
+                t1 = Orocos::Async::CORBA::TaskContext.new(ior('simple_source_source'))
+                port = t1.port("cycle",:type => :buffer,:size => 100,:period => 100)
+                port.on_data do |sample|
+                    data << sample
+                end
+                t1.configure
+                t1.start
+                1.upto(5) do |v|
+                    Orocos::Async.steps
+                    sleep 0.5
+                end
+                assert !data.empty?
+            end
+        end
     end
 end


### PR DESCRIPTION
Reads faster than period if a buffered connection is used to
empty the buffer. The events are emitted from the background
thread.