### PR TITLE
each_task returns enumerator, in case no block is given

### DIFF
--- a/lib/orocos/name_service.rb
+++ b/lib/orocos/name_service.rb
@@ -166,6 +166,7 @@ module Orocos
         #
         # @yield [TaskContext] code block which is called for each TaskContext
         def each_task
+            return enum_for(__method__) if !block_given?
             names.each do |name|
                 task = begin
                            get(name)


### PR DESCRIPTION
each_task now behaves properly, in case no block is given

As discussed here:
https://github.com/planthaber/rock-webapp/pull/17/files#r20803228

The following code part (checking if task was found) whould have beed doubled, by each task and assembling the Enumerator to return in case no block is given. So I added the new get_all function (needed for Enumerator creation anyways).

``` ruby
names.each do |name|
  task = begin
    get(name)
    rescue Orocos::NotFound
  end
  if task
    all << task
    end
end
```
