### PR TITLE
Async.proxy: add support for any object responding to name

### DIFF
--- a/lib/orocos/async/name_service.rb
+++ b/lib/orocos/async/name_service.rb
@@ -76,6 +76,11 @@ module Orocos::Async
         end
 
         def proxy(name,options = Hash.new)
+            name = if name.respond_to?(:name)
+                       name.name
+                   else
+                       name
+                   end
             options[:event_loop] ||= @event_loop
             options[:name_service] ||= self
             ns,base_name = split_name(name)


### PR DESCRIPTION
Example:
task = Orocos.get("camera")
proxy = Orcos::Async.proxy(task)
