### PR TITLE
Allow parallel build of test components

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -26,12 +26,15 @@ begin
 
     def build_orogen(name, options = Hash.new)
         require './lib/orocos/rake'
+
         parsed_options = Hash.new
         parsed_options[:keep_wc] =
             if ['1', 'true'].include?(options[:keep_wc]) then true
             else false
             end
         parsed_options[:transports] = (options[:transports] || "corba typelib mqueue").split(" ")
+        parsed_options[:make_options] = Shellwords.split(options[:make_options] || "").
+            map { |opt| opt.gsub(';', ',') }
         work_dir = File.expand_path(File.join('test', 'working_copy'))
         data_dir = File.expand_path(File.join('test', 'data'))
     
@@ -69,7 +72,7 @@ begin
 
     namespace :setup do
         desc "builds the oroGen modules that are needed by the tests"
-        task :orogen_all, [:keep_wc,:transports] do |_, args|
+        task :orogen_all, [:keep_wc,:transports,:make_options] do |_, args|
             build_orogen 'process', args
             build_orogen 'simple_sink', args
             build_orogen 'simple_source', args

--- a/Rakefile
+++ b/Rakefile
@@ -26,10 +26,18 @@ begin
 
     def build_orogen(name, options = Hash.new)
         require './lib/orocos/rake'
+        parsed_options = Hash.new
+        parsed_options[:keep_wc] =
+            if ['1', 'true'].include?(options[:keep_wc]) then true
+            else false
+            end
+        parsed_options[:transports] = (options[:transports] || "corba typelib mqueue").split(" ")
         work_dir = File.expand_path(File.join('test', 'working_copy'))
         data_dir = File.expand_path(File.join('test', 'data'))
     
-        Orocos::Rake.generate_and_build File.join(data_dir, name, "#{name}.orogen"), work_dir, options
+        Orocos::Rake.generate_and_build \
+            File.join(data_dir, name, "#{name}.orogen"),
+            work_dir, parsed_options
     end
 
     # Making sure that native extension will be build with gem

--- a/lib/orocos/rake.rb
+++ b/lib/orocos/rake.rb
@@ -43,9 +43,11 @@ module Orocos
 
             FileUtils.mkdir_p work_basedir
             work_dir = File.join(work_basedir, src_name)
-            if !keep_wc || !File.directory?(work_dir)
+            if !keep_wc
                 FileUtils.rm_rf work_dir
-                FileUtils.cp_r  src_dir, work_dir
+            end
+            FileUtils.cp_r  src_dir, work_dir, preserve: true, remove_destination: true
+
             redirect_options = Hash.new
             if make_jobserver = make_options.find { |opt| opt =~ /^--jobserver-fds=\d+,\d+$/ }
                 make_jobserver =~ /^--jobserver-fds=(\d+),(\d+)$/

--- a/lib/orocos/rake.rb
+++ b/lib/orocos/rake.rb
@@ -32,10 +32,7 @@ module Orocos
                 *options.values_at(:keep_wc, :transports, :make_options)
 
             if !transports
-                transports = %w{corba typelib}
-                if USE_MQUEUE
-                    transports << 'mqueue'
-                end
+                transports = %w{corba typelib mqueue}
                 if USE_ROS
                     transports << 'ros'
                 end


### PR DESCRIPTION
This fixes passing arguments to the rake setup:orogen* tasks, and adds an argument to pass options to the 'make' invocation. This is meant in particular to pass the relevant -j options from autoproj in Rock.
