### PR TITLE
[DO NOT MERGE: DEPENDS ON rock-core/tools-pocolog#2] log: only decode data for streams that are listening to it

### DIFF
--- a/lib/orocos/async/log/ports.rb
+++ b/lib/orocos/async/log/ports.rb
@@ -73,12 +73,15 @@ module Orocos::Async::Log
             disable_emitting do 
                 reachable! port
             end
-            port.on_data do |sample,_|
-                emit_raw_data raw_read
-                # TODO just emit raw_data and convert it to ruby
-                # if someone is listening to (see PortProxy)
+            @on_raw_data = port.on_raw_data do |sample, _|
+                emit_raw_data sample
+            end
+            @on_raw_data.disable
+
+            @on_data = port.on_data do |sample, _|
                 emit_data sample
             end
+            @on_data.disable
         end
 
         def type?
@@ -111,6 +114,7 @@ module Orocos::Async::Log
                         listener.call sample
                     end
                 end
+                @on_data.enable
             elsif listener.event == :raw_data
                 sample = raw_last_sample
                 if sample
@@ -118,6 +122,7 @@ module Orocos::Async::Log
                         listener.call sample
                     end
                 end
+                @on_raw_data.enable
             end
             super
         end

--- a/lib/orocos/log/task_context.rb
+++ b/lib/orocos/log/task_context.rb
@@ -625,6 +625,7 @@ module Orocos
             #* file_path => path of the log file
             def initialize(log_replay,task_name,file_path,file_path_config)
                 super(task_name)
+                self.model = Orocos::Spec::TaskContext.new(Orocos.master_project, '')
                 @log_replay = log_replay
                 @invalid_ports = Hash.new # ports that could not be loaded
                 @file_path = file_path


### PR DESCRIPTION
DO NOT MERGE: This is dependent on rock-core/tools-pocolog#2

This modifies Replay#step and the Log::* classes to lazy-read
the samples from the files instead of reading them eagerly. In
addition, the infrastructure got modified to properly propagate
raw samples and convert to ruby values on-demand.

This really optimizes the common case of processing only a few
streams very well.

I've only taken care of the incremental case (i.e. add new listeners
dynamically). The decremental case (where listeners are removed) is
as always a lot more complex and currently really not on the hot path.