### PR TITLE
clean before compiling in default task

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -57,7 +57,10 @@ begin
     end
 
     Rake.clear_tasks(/^default$/)
-    task :default => ["compile", "setup:uic"]
+    task 'default' do
+        Rake::Task['clean'].invoke
+        Rake::Task['compile'].invoke
+    end
 
     # Leave in top level namespace to allow rake-compiler to build native gem: 'rake native gem'
     require 'rake/extensiontask'


### PR DESCRIPTION
rake-compiler is utterly broken when it comes to dependency tracking,
and will fail to rebuild if some of the depended-upon files have
changed.

This makes sure that at least when autoproj triggers the build
the result is what is expected.