### PR TITLE
Revert "use disconnect_all to disconnect readers"

### DIFF
--- a/lib/orocos/output_reader.rb
+++ b/lib/orocos/output_reader.rb
@@ -47,7 +47,7 @@ module Orocos
 
         # Disconnects this port from the port it is reading
         def disconnect
-            port.disconnect_all
+            port.disconnect_from(self)
         end
     end
 end


### PR DESCRIPTION
This commit leads to the issue that tasks don't write out any data, since all output ports are on startup disconnected. But I don't know where this is triggerd.
Reverting this commit solves the problem for me.