### PR TITLE
fixed version of "use disconnect_all in OutputReader#disconnect"

### DIFF
--- a/lib/orocos/output_reader.rb
+++ b/lib/orocos/output_reader.rb
@@ -47,7 +47,7 @@ module Orocos
 
         # Disconnects this port from the port it is reading
         def disconnect
-            port.disconnect_from(self)
+            disconnect_all
         end
     end
 end

--- a/test/test_ports.rb
+++ b/test/test_ports.rb
@@ -488,6 +488,30 @@ describe Orocos::OutputReader do
         end
     end
 
+    describe "#disconnect" do
+        it "disconnects from the port" do
+            task = new_ruby_task_context 'test' do
+                output_port 'out', '/double'
+            end
+            reader = task.out.reader
+            reader.disconnect
+            assert !reader.connected?
+            assert !task.out.connected?
+        end
+
+        it "does not affect the port's other connections" do
+            task = new_ruby_task_context 'test' do
+                output_port 'out', '/double'
+            end
+            reader0 = task.out.reader
+            reader1 = task.out.reader
+            reader0.disconnect
+            assert !reader0.connected?
+            assert reader1.connected?
+            assert task.out.connected?
+        end
+    end
+
     if Orocos::SelfTest::USE_MQUEUE
         it "should fallback to CORBA if connection fails with MQ" do
             begin


### PR DESCRIPTION
This time with unit tests