### PR TITLE
Initialization of Orocos::RemoteProcesses failed

### DIFF
--- a/lib/orocos/remote_processes/client.rb
+++ b/lib/orocos/remote_processes/client.rb
@@ -1,3 +1,5 @@
+require 'orocos/remote_processes/loader'
+
 module Orocos
     module RemoteProcesses
     # Client-side API to a {Server} instance


### PR DESCRIPTION
 Required module class Loader could not be found

Added ```require 'orocos/remote_processes/loader'``` to make it available.

see also rock-core/tools-syskit#43