### PR TITLE
Configuration::apply: improve error handling

### DIFF
--- a/lib/orocos/configurations.rb
+++ b/lib/orocos/configurations.rb
@@ -729,7 +729,7 @@ module Orocos
                     raise ArgumentError, "no configuration available for #{model_name}"
                 end
             end
-            
+
             # If no names are given try to figure them out 
             if !names || names.empty?
                 if(task_conf.sections.size == 1)
@@ -737,7 +737,7 @@ module Orocos
                 else
                     ["default"]
                 end
-            else names
+            else Array(names)
             end
         end
 

--- a/lib/orocos/configurations.rb
+++ b/lib/orocos/configurations.rb
@@ -708,6 +708,9 @@ module Orocos
             options, find_options = Kernel.filter_options options, :override => false, :model_name => task.model.name
 
             model_name = options[:model_name]
+            if model_name.nil?
+                raise ArgumentError, "applying configuration on #{task.name} failed. #{task.class} has no model name."
+            end
             task_conf = find_task_configuration_object(task, find_options.merge(:model_name => model_name))
             if names = resolve_requested_configuration_names(model_name, task_conf, names)
                 ConfigurationManager.info "applying configuration #{names.join(", ")} on #{task.name} of type #{model_name}"

--- a/lib/orocos/task_context_base.rb
+++ b/lib/orocos/task_context_base.rb
@@ -215,6 +215,7 @@ module Orocos
                 options = Kernel.validate_options options, :provides => nil
                 return Orocos.name_service.get_provides(options[:provides].to_str)
             else
+                raise ArgumentError, 'no task name' if options.nil?
                 name = options.to_str
             end
             result = Orocos.name_service.get(name,{:process => process})


### PR DESCRIPTION
Get a propper warning if a task without model (default model)
is configured. This happens for example if a Log::TaskContext
is tried to be configured.