### PR TITLE
async: Add OroGen::DefinitionTypekitNotFound as known error

### DIFF
--- a/lib/orocos/async/async.rb
+++ b/lib/orocos/async/async.rb
@@ -70,7 +70,7 @@ require 'utilrb/event_loop'
 # asynchronous object.
 #
 module Orocos::Async
-    KNOWN_ERRORS = [Orocos::ComError,Orocos::NotFound,Typelib::NotFound,Orocos::TypekitTypeNotFound,Orocos::TypekitTypeNotExported,Orocos::StateTransitionFailed,Orocos::ConnectionFailed]
+    KNOWN_ERRORS = [Orocos::ComError,Orocos::NotFound,Typelib::NotFound,Orocos::TypekitTypeNotFound,Orocos::TypekitTypeNotExported,Orocos::StateTransitionFailed,Orocos::ConnectionFailed,OroGen::DefinitionTypekitNotFound]
     class << self
         extend ::Forwardable
 


### PR DESCRIPTION
Merge only after applying orocos-toolchain/orogen#48 to handle errors in rock-display