### PR TITLE
TaskContextBase NoMethodError: include name of the task

### DIFF
--- a/lib/orocos/task_context_base.rb
+++ b/lib/orocos/task_context_base.rb
@@ -821,7 +821,11 @@ module Orocos
                     return value
                 end
             end
-            super(m.to_sym, *args)
+            begin
+                super(m.to_sym, *args)
+            rescue NoMethodError => e
+                raise $!,"undefined method '#{m}' for #{self}",$!.backtrace
+            end
         end
 
         def to_h


### PR DESCRIPTION
By default to_s is not used and only the class + object_id is
used as error message