### PR TITLE
MacOS X Support

### DIFF
--- a/lib/orocos/base.rb
+++ b/lib/orocos/base.rb
@@ -105,6 +105,23 @@ module Orocos
         @default_pkgconfig_loader ||= OroGen::Loaders::PkgConfig.new(orocos_target, default_loader)
     end
 
+    @macos =  RbConfig::CONFIG["host_os"] =~%r!([Dd]arwin)!
+    def self.macos?
+        @macos
+    end
+
+    @windows = RbConfig::CONFIG["host_os"] =~%r!(msdos|mswin|djgpp|mingw|[Ww]indows)!
+    def self.windows?
+        @windows
+    end
+
+    def self.shared_library_suffix
+        if macos? then 'dylib'
+        elsif windows? then 'dll'
+        else 'so'
+        end
+    end
+
     def self.orocos_target
         if ENV['OROCOS_TARGET']
             ENV['OROCOS_TARGET']

--- a/lib/orocos/task_context.rb
+++ b/lib/orocos/task_context.rb
@@ -380,6 +380,7 @@ module Orocos
                 begin
                     do_has_port?(name)
                 rescue Orocos::NotFound
+                rescue Orocos::CORBAError
                     false
                 end
             end

--- a/lib/orocos/typekits.rb
+++ b/lib/orocos/typekits.rb
@@ -28,7 +28,7 @@ module Orocos
     # full path to the library
     def self.find_plugin_library(pkg, libname)
         pkg.library_dirs.find do |dir|
-            full_path = File.join(dir, "lib#{libname}.so")
+            full_path = File.join(dir, "lib#{libname}.#{Orocos.shared_library_suffix}")
             break(full_path) if File.file?(full_path)
         end
     end


### PR DESCRIPTION
Added Orocos.macos? and Orocos.windows? (unused so far)
Orocos.shared_library_suffix (so for linux and dylib for macos)
This is used within find_plugin_library.