### PR TITLE
async: normalize given port/attribute/property names to strings

### DIFF
--- a/lib/orocos/async/task_context_proxy.rb
+++ b/lib/orocos/async/task_context_proxy.rb
@@ -563,6 +563,7 @@ module Orocos::Async
         end
 
         def property(name,options = Hash.new)
+            name = name.to_str
             options,other_options = Kernel.filter_options options,:wait => @options[:wait]
             wait if options[:wait]
 
@@ -591,6 +592,7 @@ module Orocos::Async
         end
 
         def attribute(name,options = Hash.new)
+            name = name.to_str
             options,other_options = Kernel.filter_options options,:wait => @options[:wait]
             wait if options[:wait]
 
@@ -619,6 +621,7 @@ module Orocos::Async
         end
 
         def port(name,options = Hash.new)
+            name = name.to_str
             options,other_options = Kernel.filter_options options,:wait => @options[:wait]
             wait if options[:wait]
 


### PR DESCRIPTION
Otherwise, this:
  proxy.property(:property_name)

will successfully return a useless object