### PR TITLE
Fix type exports

### DIFF
--- a/lib/orocos.rb
+++ b/lib/orocos.rb
@@ -19,6 +19,7 @@ rescue LoadError => e
     exit 1
 end
     
+require 'typelib'
 require 'orocos/base'
 require 'orocos/default_loader'
 require 'orocos/typekits'

--- a/lib/orocos/typekits.rb
+++ b/lib/orocos/typekits.rb
@@ -1,5 +1,4 @@
-module Types
-end
+Types = Typelib::RegistryExport::Namespace.new
 
 module Orocos
     class << self


### PR DESCRIPTION
The toplevel 'Types' constant must now be an instance of
Typelib::RegistryExport::Namespace