### PR TITLE
Async: fix once_on_EVENT called more than once

### DIFF
--- a/lib/orocos/async/object_base.rb
+++ b/lib/orocos/async/object_base.rb
@@ -130,7 +130,7 @@ module Orocos::Async
                             end
                             def once_on_#{n}(use_last_value = true,&block)
                                 l = on_event #{n.inspect},use_last_value do |*args|
-                                       block.call(*args)
+                                       block.call(*args) if l.listening?
                                        l.stop
                                     end
                             end


### PR DESCRIPTION
once_on_XXXX was called more than once for events with a frequency
higher than the eventloop.