### PR TITLE
Do not rescue CORBAError in has_port?

### DIFF
--- a/lib/orocos/task_context.rb
+++ b/lib/orocos/task_context.rb
@@ -380,7 +380,6 @@ module Orocos
                 begin
                     do_has_port?(name)
                 rescue Orocos::NotFound
-                rescue Orocos::CORBAError
                     false
                 end
             end


### PR DESCRIPTION
This was introduced as the (wrong) bugfix of a deeper bug on MacOSX,
where do_has_port? would raise CORBAError instead of NotFound

Even though it will most probably break some stuff on MacOSX, this
has to disappear. It is currently completely misrepresenting dead
tasks by saying that they do not have a port instead of reporting
that they are simply *not there*. I noticed it because it had bad
consequences at runtime in Syskit.