### PR TITLE
oroconf: fix w.r.t change in the orogen loaders

### DIFF
--- a/bin/oroconf
+++ b/bin/oroconf
@@ -98,7 +98,7 @@ when "extract"
     if !model_name
         STDERR.puts "missing a model name as argument"
     end
-    if !Orocos.default_loader.find_task_library_from_task_model_name(model_name)
+    if !Orocos.default_pkgconfig_loader.find_task_library_from_task_model_name(model_name)
         STDERR.puts "#{model_name} is not a known model name"
     end
 


### PR DESCRIPTION
Aggregate cannot resolve projects by task names, only the pkg_config
loader can.