### PR TITLE
Speedup plugin loading

### DIFF
--- a/bin/orops
+++ b/bin/orops
@@ -3,6 +3,7 @@
 require 'orocos'
 require 'pp'
 require 'utilrb/pkgconfig'
+require 'optparse'
 
 do_cleanup = false
 parser = OptionParser.new do |opt|

--- a/bin/oroshell
+++ b/bin/oroshell
@@ -2,6 +2,7 @@
 
 require 'irb'
 require 'orocos'
+require 'optparse'
 
 parser = OptionParser.new do |opt|
     opt.on('--host=HOST', String, "the host we should connect to for naming") do |hostname|

--- a/lib/orocos/process.rb
+++ b/lib/orocos/process.rb
@@ -345,8 +345,8 @@ module Orocos
     # starting the process and cleaning up when the process
     # dies.
     class Process < ProcessBase
-        # The component PkgConfig instance
-        attr_reader :pkg
+        # The path to the binary file
+        attr_reader :binfile
         # The component process ID
         attr_reader :pid
 
@@ -430,7 +430,11 @@ module Orocos
                         loader.deployment_model_from_name(model)
                     else model
                     end
-            @pkg = loader.available_deployments[model.name]
+            @binfile =
+                if loader.respond_to?(:find_deployment_binfile)
+                    loader.find_deployment_binfile(model.name)
+                else loader.available_deployments[model.name].binfile
+                end
             super(name, model)
         end
 
@@ -951,11 +955,7 @@ module Orocos
 		ENV['ORBInitRef'] = "NameService=corbaname::#{name_service.ip}"
 	    end
 
-            module_bin = pkg.binfile
-            if !module_bin # assume an older orogen version
-                module_bin = "#{pkg.exec_prefix}/bin/#{name}"
-            end
-            cmdline = [module_bin]
+            cmdline = [binfile]
 
             # check arguments for log_level
             if log_level

--- a/lib/orocos/typekits.rb
+++ b/lib/orocos/typekits.rb
@@ -76,8 +76,7 @@ module Orocos
     def self.load_typekit(name)
         @lock.synchronize do
             typekit = default_pkgconfig_loader.typekit_model_from_name(name)
-            typekit_pkg = find_typekit_pkg(name)
-            load_typekit_plugins(name, typekit_pkg)
+            load_typekit_plugins(name)
         end
     end
 

--- a/lib/orocos/typekits.rb
+++ b/lib/orocos/typekits.rb
@@ -26,9 +26,13 @@ module Orocos
     # Given a pkg-config file and a base name for a shared library, finds the
     # full path to the library
     def self.find_plugin_library(pkg, libname)
-        pkg.library_dirs.find do |dir|
+        libs = pkg.expand_field('Libs', pkg.raw_fields['Libs'])
+        libs = libs.grep(/^-L/).map { |s| s[2..-1] }
+        libs.find do |dir|
             full_path = File.join(dir, "lib#{libname}.#{Orocos.shared_library_suffix}")
-            break(full_path) if File.file?(full_path)
+            if File.file?(full_path)
+                return full_path, libs
+            end
         end
     end
 
@@ -78,7 +82,7 @@ module Orocos
     end
 
     def self.find_typekit_pkg(name)
-        Utilrb::PkgConfig.new("#{name}-typekit-#{Orocos.orocos_target}")
+        Utilrb::PkgConfig.get("#{name}-typekit-#{Orocos.orocos_target}", minimal: true)
     rescue Utilrb::PkgConfig::NotFound
         raise TypekitNotFound, "the '#{name}' typekit is not available to pkgconfig"
     end
@@ -142,7 +146,7 @@ module Orocos
             AUTOLOADED_TRANSPORTS.each do |transport_name, required|
                 plugin_name = transport_library_name(name, transport_name, Orocos.orocos_target)
                 begin
-                    pkg = Utilrb::PkgConfig.new(plugin_name)
+                    pkg = Utilrb::PkgConfig.get(plugin_name, minimal: true)
                     if pkg.disabled != "true"
                         plugins[plugin_name] = [pkg, required]
                     elsif required
@@ -157,12 +161,12 @@ module Orocos
         end
 
         plugins.each_pair do |file, (pkg, required)| 
-            lib = find_plugin_library(pkg, file)
+            lib, lib_dirs = find_plugin_library(pkg, file)
             if !lib
                 if required
-                    raise NotFound, "cannot find shared library #{file} for #{name} (searched in #{pkg.library_dirs.join(", ")})"
+                    raise NotFound, "cannot find shared library #{file} for #{name} (searched in #{lib_dirs})"
                 else
-                    Orocos.warn "plugin #{file} is registered through pkg-config, but the library cannot be found in #{pkg.library_dirs.join(", ")}"
+                    Orocos.warn "plugin #{file} is registered through pkg-config, but the library cannot be found in #{lib_dirs}"
                 end
             else
                 libs << [lib, required]

--- a/manifest.xml
+++ b/manifest.xml
@@ -17,6 +17,8 @@
     <depend package="tools/pocolog" optional="1"/>
     <depend package="omniorb" />
     <depend package="tools/rtt_transports/ros" optional="1"/>
+    <depend package="hoe" />
+    <depend package="rake-compiler" />
 
     <test_depend package='flexmock' />
     <test_depend package='fakefs' />


### PR DESCRIPTION
This depends on https://github.com/orocos-toolchain/utilrb/pull/30 and https://github.com/orocos-toolchain/orogen/pull/77

Instead of doing full pkg-config file resolution, we only extract the information that is really needed. It fixes the performance hit caused by the application of https://github.com/orocos-toolchain/orogen/pull/77.