### PR TITLE
ruby_tasks: call the #create methods with the typelib type object

### DIFF
--- a/lib/orocos/ruby_tasks/task_context.rb
+++ b/lib/orocos/ruby_tasks/task_context.rb
@@ -212,13 +212,13 @@ module Orocos
             remove_inputs.each { |p| remove_input_port p }
             remove_outputs.each { |p| remove_output_port p }
             new_properties.each do |p|
-                create_property(p.name, p.orocos_type_name)
+                create_property(p.name, p.type)
             end
             new_inputs.each do |p|
-                create_input_port(p.name, p.orocos_type_name)
+                create_input_port(p.name, p.type)
             end
             new_outputs.each do |p|
-                create_output_port(p.name, p.orocos_type_name)
+                create_output_port(p.name, p.type)
             end
             @model = orogen_model
             nil


### PR DESCRIPTION
The create methods already do the resolution, and this ensures that
all types are normalized properly.

It fixes an issue where the orocos type name was non-normalized (float)
and as such the resolution did not find the corresponding type name.