### PR TITLE
load the 'std' typekit before the RTT typekit

### DIFF
--- a/lib/orocos/base.rb
+++ b/lib/orocos/base.rb
@@ -180,6 +180,7 @@ module Orocos
         @loaded_typekit_plugins.clear
         @max_sizes = Hash.new { |h, k| h[k] = Hash.new }
 
+        load_typekit 'std'
         load_standard_typekits
 
         if Orocos::ROS.enabled?
@@ -281,7 +282,6 @@ module Orocos
                 Orocos::Async.name_service.add(ns)
             end
         end
-        load_typekit 'std'
         @ruby_task = RubyTasks::TaskContext.new(name)
     end
 


### PR DESCRIPTION
This ensures that all types on the orocos side are normalized (i.e.
typelib type names) instead of the horrible mix we currently have.

Must be merged at the same time than orocos-toolchain/orogen#83