### PR TITLE
async: avoid converting data to ruby unnecessarily

### DIFF
--- a/lib/orocos/async/object_base.rb
+++ b/lib/orocos/async/object_base.rb
@@ -331,11 +331,11 @@ module Orocos::Async
 
         # calls all listener which are registered for the given event
         # the next step
-        def event(event_name,*args)
+        def event(event_name,*args,&block)
             validate_event event_name
             return unless @emitting
             @event_loop.once do
-                process_event event_name,*args
+                process_event event_name,*args,&block
             end
             self
         end
@@ -386,8 +386,9 @@ module Orocos::Async
 
         private
         # calls all listener which are registered for the given event
-        def process_event(event_name,*args)
+        def process_event(event_name,*args,&block)
             event = validate_event event_name
+            args = block.call if block
             #@listeners have to be cloned because it might get modified 
             #by listener.call
             @listeners[event_name].clone.each do |listener|

--- a/lib/orocos/async/ports.rb
+++ b/lib/orocos/async/ports.rb
@@ -116,15 +116,15 @@ module Orocos::Async::CORBA
 
         # blocking method called from thread pool to read new data
         def thread_read(timeout)
-            t1 = Time.now
+            deadline = Time.now + timeout
             raw_last_sample = nil
             while data = raw_read_new # sync call from bg thread
                 raw_last_sample = data
                 event :raw_data, data
                 # TODO just emit raw_data and convert it to ruby
                 # if someone is listening to (see PortProxy)
-                event :data, Typelib.to_ruby(data)
-                break if (Time.now-t1).to_f >= timeout
+                event(:data) { [Typelib.to_ruby(data)] }
+                break if Time.now > deadline
             end
             raw_last_sample
         end


### PR DESCRIPTION
This is potentially an expensive operation, so delay it until it
is actually needed