### PR TITLE
add OBJ_ADAPTER as a class of corba errors reported as ComError

### DIFF
--- a/ext/rorocos/corba.hh
+++ b/ext/rorocos/corba.hh
@@ -89,6 +89,7 @@ extern void corba_must_be_initialized();
     catch(CORBA::TRANSIENT& e) { this->rb_raise(eCORBAComError, "CORBA transient exception: %s", e.NP_minorString()); } \
     catch(CORBA::INV_OBJREF& e) { this->rb_raise(eCORBA, "CORBA invalid obj reference: %s", e.NP_minorString()); } \
     catch(CORBA::OBJECT_NOT_EXIST& e) { this->rb_raise(eCORBAComError, "CORBA referenced object does not exist: %s", e.NP_minorString()); } \
+    catch(CORBA::OBJ_ADAPTER& e) { this->rb_raise(eCORBAComError, "POA adapter error: %s", e.NP_minorString()); } \
     catch(CORBA::SystemException& e) { this->rb_raise(eCORBA, "CORBA system exception: %s", e.NP_minorString()); } \
     catch(CORBA::Exception& e) { this->rb_raise(eCORBA, "unspecified error in the CORBA layer: %s", typeid(e).name()); } \
     catch(InvalidIORError &e) { this->rb_raise(rb_eArgError, e.what());}

--- a/lib/orocos/ruby_tasks/task_context.rb
+++ b/lib/orocos/ruby_tasks/task_context.rb
@@ -236,6 +236,10 @@ module Orocos
             @local_ports.has_key?(name) || super
         end
 
+        def raw_port(name)
+            @local_ports[name] || super
+        end
+
         private
 
         # Helper method for create_input_port and create_output_port


### PR DESCRIPTION
They happen when we shutdown a remote process uncleanly, and that's what
ComError is expected to represent.