### PR TITLE
log: don't filter out ports that have no samples

### DIFF
--- a/lib/orocos/log/replay.rb
+++ b/lib/orocos/log/replay.rb
@@ -422,10 +422,7 @@ module Orocos
 
                 #get all streams which shall be replayed
                 each_port do |port|
-                    if port.used?
-                        next if port.stream.empty?
-                        @replayed_ports << port
-                    end
+                    @replayed_ports << port if port.used?
                 end
 
                 Log.info "Aligning streams --> all ports which are unused will not be loaded!!!"

--- a/test/log/test_replay.rb
+++ b/test/log/test_replay.rb
@@ -45,7 +45,29 @@ module Orocos
                     @log_replay.load_task_from_stream(@stream, '/some/path/to/port.0.log')
                 end
             end
+
+            describe "#align" do
+                before do
+                    dir = make_tmpdir
+                    registry = Typelib::CXXRegistry.new
+                    logfile = Pocolog::Logfiles.create(
+                            File.join(dir, 'somefile'), registry)
+                    logfile.create_stream 'test_stream', '/double',
+                        'rock_task_name' => 'task_name',
+                        'rock_task_object_name' => 'port_name',
+                        'rock_cxx_type_name' => '/double',
+                        'rock_stream_type' => 'port'
+                    logfile.close
+                    logfile = Pocolog::Logfiles.open(File.join(dir, 'somefile.0.log'))
+                    @stream = logfile.streams.first
+                end
+
+                it "aligns empty streams" do
+                    @log_replay.load_task_from_stream(@stream, "log_file")
+                    @log_replay.align
+                    assert @log_replay.used_streams.include?(@stream)
+                end
+            end
         end
     end
 end
-


### PR DESCRIPTION
Depends on:
- [x] https://github.com/rock-core/tools-pocolog/pull/18

If the port is used, it should be present on the aligner. The
refactored pocolog started (rightly) raising if the stream
aligner is being queried about a stream it's not aligning,
and this broke Vizkit.

Basically, vizkit items are enumerating all ports. Because
pocolog master is simply returning zero and nil for streams
that are not being aligned, Vizkit was happily showing empty
streams and the fact that we're not validating stream aligner's
input was silently ignored.