### PR TITLE
switch the priority of rock_orocos_type_name and rock_cxx_type_name

### DIFF
--- a/lib/orocos/log/task_context.rb
+++ b/lib/orocos/log/task_context.rb
@@ -69,13 +69,9 @@ module Orocos
 
             def guess_orocos_type_name(stream)
                 metadata = stream.metadata || Hash.new
-                if (name = metadata['rock_cxx_type_name'])
-                    return name
-                end
-
                 if (name = metadata['rock_orocos_type_name'])
-                    Log.warn "stream '#{stream.name}' has no rock_cxx_type_name metadata, "\
-                        "using the rock_orocos_type_name metadata instead"
+                    return name
+                elsif (name = metadata['rock_cxx_type_name'])
                     return name
                 end
 

--- a/lib/orocos/ports_base.rb
+++ b/lib/orocos/ports_base.rb
@@ -78,7 +78,8 @@ module Orocos
                 'rock_task_name' => task.name,
                 'rock_task_object_name' => name,
                 'rock_stream_type' => 'port',
-                'rock_orocos_type_name' => orocos_type_name]
+                'rock_orocos_type_name' => orocos_type_name,
+                'rock_cxx_type_name' => orocos_type_name]
 
 	    if Orocos.logger_guess_timestamp_field?
 		# see if we can find a time field in the type, which

--- a/lib/orocos/task_context_base.rb
+++ b/lib/orocos/task_context_base.rb
@@ -45,7 +45,8 @@ module Orocos
             Hash['rock_task_model' => (task.model.name || ''),
                 'rock_task_name' => task.name,
                 'rock_task_object_name' => name,
-                'rock_orocos_type_name' => orocos_type_name]
+                'rock_orocos_type_name' => orocos_type_name,
+                'rock_cxx_type_name' => orocos_type_name]
         end
 
         def ensure_type_available(options = Hash.new)

--- a/test/log/test_interface_object.rb
+++ b/test/log/test_interface_object.rb
@@ -14,7 +14,7 @@ module Orocos
                             File.join(dir, 'somefile.0.log'), registry)
                         @stream = @logfile.create_stream 'test.pattern', '/double',
                             'rock_task_object_name' => 'test',
-                            'rock_cxx_type_name' => '/cxx/type/name'
+                            'rock_orocos_type_name' => '/cxx/type/name'
                     end
 
                     it "uses the rock_task_object_name metadata by default" do
@@ -33,7 +33,7 @@ module Orocos
                     it "finally falls back to the whole stream name if the name does not "\
                         "match the PORT.NAME pattern" do
                         stream = @logfile.create_stream 'test_pattern', '/double',
-                            'rock_cxx_type_name' => '/cxx/type/name'
+                            'rock_orocos_type_name' => '/cxx/type/name'
 
                         flexmock(Log).should_receive(:warn).
                             with("stream 'test_pattern' has no rock_task_object_name "\
@@ -55,26 +55,22 @@ module Orocos
                             File.join(dir, 'somefile.0.log'), registry)
                         @stream = logfile.create_stream 'test.pattern', '/double',
                             'rock_task_object_name' => 'test',
-                            'rock_orocos_type_name' => '/orocos/type/name',
-                            'rock_cxx_type_name' => '/cxx/type/name'
+                            'rock_cxx_type_name' => '/orocos/type/name',
+                            'rock_orocos_type_name' => '/cxx/type/name'
                     end
 
-                    it "uses first the rock_cxx_type_name metadata" do
+                    it "uses first the rock_orocos_type_name metadata" do
                         object = InterfaceObject.new(@stream)
                         assert_equal '/cxx/type/name', object.orocos_type_name
                     end
-                    it "first falls back to rock_orocos_type_name metadata" do
-                        @stream.metadata.delete 'rock_cxx_type_name'
-                        flexmock(Log).should_receive(:warn).
-                            with("stream 'test.pattern' has no rock_cxx_type_name "\
-                                 "metadata, using the rock_orocos_type_name metadata "\
-                                 "instead").once
+                    it "first falls back to rock_cxx_type_name metadata" do
+                        @stream.metadata.delete 'rock_orocos_type_name'
                         object = InterfaceObject.new(@stream)
                         assert_equal '/orocos/type/name', object.orocos_type_name
                     end
                     it "uses the type name last" do
-                        @stream.metadata.delete 'rock_orocos_type_name'
                         @stream.metadata.delete 'rock_cxx_type_name'
+                        @stream.metadata.delete 'rock_orocos_type_name'
                         flexmock(Log).should_receive(:warn).
                             with("stream 'test.pattern' has neither the "\
                                  "rock_cxx_type_name nor the rock_orocos_type_name "\
@@ -84,8 +80,8 @@ module Orocos
                         assert_equal '/double', object.orocos_type_name
                     end
                     it "filters out the _m type pattern when using the type name" do
-                        @stream.metadata.delete 'rock_orocos_type_name'
                         @stream.metadata.delete 'rock_cxx_type_name'
+                        @stream.metadata.delete 'rock_orocos_type_name'
                         flexmock(@stream.type).should_receive(name: '/double_m')
                         flexmock(Log).should_receive(:warn).
                             with("stream 'test.pattern' has neither the "\


### PR DESCRIPTION
rock_cxx_type_name has actually been introduced to tools/logger
even though rocks_orocos_type_name was already standardized
in http://rock.opendfki.de/trac/wiki/WikiStart/Standards/RG8 for
the same purpose.

Generate both fields in property and port logging, and remove
a warning. We fucked up, let's not worry our users unnecessarily