### PR TITLE
make sure the CORBA CConnPolicy is pre-filled with sane defaults

### DIFF
--- a/ext/rorocos/rorocos.cc
+++ b/ext/rorocos/rorocos.cc
@@ -395,7 +395,7 @@ static VALUE port_connected_p(VALUE self)
 
 static RTT::corba::CConnPolicy policyFromHash(VALUE options)
 {
-    RTT::corba::CConnPolicy result;
+    RTT::corba::CConnPolicy result = RTT::coba::toCORBA(RTT::ConnPolicy());
     VALUE conn_type_value = rb_hash_aref(options, ID2SYM(rb_intern("type")));
     VALUE conn_type = SYM2ID(conn_type_value);
     if (conn_type == rb_intern("data"))


### PR DESCRIPTION
RTT master added new fields to the policy. This commit makes sure
that these new fields are filled with sane defaults, in a backward-
and forward- compatible way.