### PR TITLE
suggest to clean the omniorb log when the system fails to connect to a CORBA server

### DIFF
--- a/lib/orocos/corba.rb
+++ b/lib/orocos/corba.rb
@@ -98,6 +98,23 @@ module Orocos
 	    result
 	end
 
+        # Stop and restart name server to resolve Orocos::CORBA::ComError
+        # 
+        # @ return [Boolean]
+        def restart_name_server?
+            system("sudo", "/etc/init.d/omniorb4-nameserver", "stop")
+            system("echo", "       Removing /var/lib/omniorb/*")
+            # needs to be a sub shell (exec) due to write-protection
+            # fork is needed to keep the script running after exec execution
+            exec("sudo rm -f /var/lib/omniorb/* && exit") if fork.nil?
+            system("sudo", "/etc/init.d/omniorb4-nameserver", "start")
+            puts "Successfully restarted omniorb4-nameserver"
+            return true
+          raise SystemCallError
+            puts "Restarting omniorb4-nameserver failed"
+            return false
+        end
+
         # Deinitializes the CORBA layer
         #
         # It shuts down the CORBA access and deregisters the Ruby process from
@@ -117,7 +134,13 @@ module Orocos
 
         rescue ComError => e
             if !obj1
-                raise ComError, "communication failed with #{obj0}", e.backtrace
+                CORBA.warn "Communication failed with #{obj0}"
+                CORBA.warn "{e.backtrace}\n"
+                puts "Restarting omniorb4 nameserver. Sudo required.."
+                unless restart_name_server?
+                  puts "Try to manually restart the omniorb4 nameserver at /etc/init.d/omniorb4-nameserver"
+                  exit
+                end
             else
                 raise ComError, "communication failed with either #{obj0} or #{obj1}", e.backtrace
             end

--- a/lib/orocos/corba.rb
+++ b/lib/orocos/corba.rb
@@ -117,12 +117,7 @@ module Orocos
 
         rescue ComError => e
             if !obj1
-                CORBA.warn "Communication failed with corba #{obj0}"
-                puts "You can fix this by manually restarting the nameserver:"
-                puts "    sudo /etc/init.d/omniorb4-nameserver stop"
-                puts "    sudo rm -f /var/lib/omniorb/*"
-                puts "    sudo /etc/init.d/omniorb4-nameserver start"
-                raise ComError, e.backtrace
+                raise ComError, "Communication failed with corba #{obj0}", e.backtrace
             else
                 raise ComError, "communication failed with either #{obj0} or #{obj1}", e.backtrace
             end

--- a/lib/orocos/name_service.rb
+++ b/lib/orocos/name_service.rb
@@ -141,11 +141,6 @@ module Orocos
             validate
             true
         rescue
-            Orocos::CORBA.warn "Name service is unreachable."
-            puts "You can try to fix this manually by restarting the nameserver:"
-            puts "    sudo /etc/init.d/omniorb4-nameserver stop"
-            puts "    sudo rm -f /var/lib/omniorb/*"
-            puts "    sudo /etc/init.d/omniorb4-nameserver start"
             false
         end
 
@@ -650,7 +645,16 @@ module Orocos
             #(see NameServiceBase#validate)
             def validate
                 CORBA.refine_exceptions("corba naming service #{ip}") do
-                    do_validate
+                    begin
+                        do_validate
+                    rescue Orocos::ComError => e
+                        CORBA.warn "Name service is unreachable: #{e.message}\n"
+                        puts "You can try to fix this manually by restarting the nameserver:"
+                        puts "    sudo /etc/init.d/omniorb4-nameserver stop"
+                        puts "    sudo rm -f /var/lib/omniorb/*"
+                        puts "    sudo /etc/init.d/omniorb4-nameserver start"
+                        raise Orocos::ComError, e.backtrace
+                    end
                 end
             end
 

--- a/lib/orocos/name_service.rb
+++ b/lib/orocos/name_service.rb
@@ -141,6 +141,11 @@ module Orocos
             validate
             true
         rescue
+            Orocos::CORBA.warn "Name service is unreachable."
+            puts "You can try to fix this manually by restarting the nameserver:"
+            puts "    sudo /etc/init.d/omniorb4-nameserver stop"
+            puts "    sudo rm -f /var/lib/omniorb/*"
+            puts "    sudo /etc/init.d/omniorb4-nameserver start"
             false
         end
 

--- a/lib/orocos/name_service.rb
+++ b/lib/orocos/name_service.rb
@@ -649,11 +649,11 @@ module Orocos
                         do_validate
                     rescue Orocos::ComError => e
                         CORBA.warn "Name service is unreachable: #{e.message}\n"
-                        puts "You can try to fix this manually by restarting the nameserver:"
-                        puts "    sudo /etc/init.d/omniorb4-nameserver stop"
-                        puts "    sudo rm -f /var/lib/omniorb/*"
-                        puts "    sudo /etc/init.d/omniorb4-nameserver start"
-                        raise Orocos::ComError, e.backtrace
+                        CORBA.warn "You can try to fix this manually by restarting the nameserver:\n"
+                        CORBA.warn "    sudo /etc/init.d/omniorb4-nameserver stop\n"
+                        CORBA.warn "    sudo rm -f /var/lib/omniorb/*\n"
+                        CORBA.warn "    sudo /etc/init.d/omniorb4-nameserver start\n"
+                        raise
                     end
                 end
             end


### PR DESCRIPTION
A common enough problem on Ubuntu is that the omniorb log is invalid, which makes the service fail on startup. Suggest how to solve that in a warning message when the CORBA server fails to connect.