### PR TITLE
pass conversion C++ exceptions to ruby

### DIFF
--- a/ext/rorocos/datahandling.cc
+++ b/ext/rorocos/datahandling.cc
@@ -72,9 +72,10 @@ CORBA::Any* ruby_to_corba(std::string const& type_name, Typelib::Value src)
     else
     {
         orogen_transports::TypelibMarshallerBase::Handle* handle = typelib_transport->createHandle();
-        try { typelib_transport->setTypelibSample(handle, src); }
-        catch(std::exception& e)
-        {
+        try {
+            typelib_transport->setTypelibSample(handle, src);
+        }
+        catch(std::exception& e) {
             rb_raise(eCORBA, "failed to marshal %s: %s", type_name.c_str(), e.what());
         }
 

--- a/lib/orocos/output_reader.rb
+++ b/lib/orocos/output_reader.rb
@@ -7,20 +7,6 @@ module Orocos
         # The policy of the connection
         attr_accessor :policy
 
-        # Helper method for #read and #read_new
-        #
-        # This is overloaded in OutputReader to raise CORBA::ComError if the
-        # process supporting the remote task is known to be dead
-        def read_helper(sample, copy_old_data)
-	    if process = port.task.process
-		if !process.alive?
-		    disconnect_all
-		    raise CORBA::ComError, "remote end is dead"
-		end
-	    end
-            super
-        end
-
         # Reads a sample on the associated output port. Returns a value as soon
         # as a sample has ever been written to the port since the data reader
         # has been created

--- a/lib/orocos/ruby_tasks/task_context.rb
+++ b/lib/orocos/ruby_tasks/task_context.rb
@@ -163,9 +163,7 @@ module Orocos
         #   is mostly to avoid crashes / misbehaviours in case smart pointers are
         #   used
         # @return [Property] the property object
-        def create_property(name, type, options = Hash.new)
-            options = Kernel.validate_options options, :init => true
-
+        def create_property(name, type, init: true)
             Orocos.load_typekit_for(type, false)
             orocos_type_name = Orocos.find_orocos_type_name_by_type(type)
             Orocos.load_typekit_for(orocos_type_name, true)
@@ -173,7 +171,7 @@ module Orocos
             local_property = @local_task.do_create_property(Property, name, orocos_type_name)
             @local_properties[local_property.name] = local_property
             @properties[local_property.name] = local_property
-            if options[:init]
+            if init
                 local_property.write(local_property.new_sample)
             end
             local_property

--- a/manifest.xml
+++ b/manifest.xml
@@ -25,5 +25,6 @@
 
     <test_depend package='flexmock' />
     <test_depend package='fakefs' />
+    <test_depend package='base/orogen/types' />
 </package>
 


### PR DESCRIPTION
The C++ code (namely, the orogen opaque conversion code) may throw exceptions if the input data is invalid. Right now, that exception was not caught which would terminate the process.

Catch these exceptions and convert them to Ruby CORBAError for proper error handling.