### PR TITLE
fix corner cases related to the implicit "default" section in configuration files

### DIFF
--- a/lib/orocos/configurations.rb
+++ b/lib/orocos/configurations.rb
@@ -130,10 +130,18 @@ module Orocos
         def self.load_raw_sections_from_file(file)
             document_lines = File.readlines(file)
 
-            headers = document_lines.each_with_index.
-                find_all { |line, _| line =~ /^---/ }
-            if headers.empty? || headers.first[1] != 0
+            headers =
+                document_lines
+                .each_with_index
+                .find_all { |line, _| line =~ /^---/ }
+
+            if headers.empty?
                 headers.unshift ["--- name:default", -1]
+            elsif headers.first[1] != 0
+                leading_lines = document_lines[0, headers.first[1]].map(&:strip)
+                if leading_lines.any? { |l| !l.empty? && !l.start_with?("#") }
+                    headers.unshift ["--- name:default", -1]
+                end
             end
 
             options = headers.map do |line, line_number|

--- a/lib/orocos/configurations.rb
+++ b/lib/orocos/configurations.rb
@@ -171,7 +171,16 @@ module Orocos
             end
             sections << document_lines[options[-1][1] + 1, document_lines.size - options[-1][1] - 1]
 
-            options.map(&:first).zip(sections)
+            sections = options.map(&:first).zip(sections)
+            found_sections = []
+            sections.each do |conf_options, doc|
+                name = conf_options[:name]
+                if found_sections.include?(name)
+                    raise ArgumentError, "#{name} defined twice"
+                end
+                found_sections << name
+            end
+            sections
         end
 
         # @api private

--- a/test/test_configurations.rb
+++ b/test/test_configurations.rb
@@ -210,6 +210,22 @@ describe Orocos::TaskConfigurations do
         end
     end
 
+    it "raises if the same section is defined twice in the same file" do
+        assert_raises(ArgumentError) do
+            conf.load_from_yaml(
+                File.join(data_dir, "configurations", "duplicate_sections.yml")
+            )
+        end
+    end
+
+    it "raises even if the duplicate section is the implicit default section" do
+        assert_raises(ArgumentError) do
+            conf.load_from_yaml(
+                File.join(data_dir, "configurations", "duplicate_default.yml")
+            )
+        end
+    end
+
     it "should be able to load complex structures" do
         conf.load_from_yaml(File.join(data_dir, 'configurations', 'complex_config.yml'))
 

--- a/test/test_configurations.rb
+++ b/test/test_configurations.rb
@@ -226,6 +226,14 @@ describe Orocos::TaskConfigurations do
         end
     end
 
+    it "ignores a no-op default section at the top of the file" do
+        assert_raises(ArgumentError) do
+            conf.load_from_yaml(
+                File.join(data_dir, "configurations", "noop_default.yml")
+            )
+        end
+    end
+
     it "should be able to load complex structures" do
         conf.load_from_yaml(File.join(data_dir, 'configurations', 'complex_config.yml'))
 


### PR DESCRIPTION
This solves the issue that, currently,

```
# some
# comment

# or blank lines
--- name:default
```

would be interpreted, and mis-handled, as two "default" sections. This solves it by

1. avoid defining an implicit default section in this case
2. raise if there are duplicate sections