### PR TITLE
give finer-grained control over what happens in Process#kill

### DIFF
--- a/lib/orocos/process.rb
+++ b/lib/orocos/process.rb
@@ -1265,12 +1265,19 @@ module Orocos
 
         # Kills the process either cleanly by requesting a shutdown if signal ==
         # nil, or forcefully by using UNIX signals if signal is a signal name.
-        def kill(wait = true, signal = nil)
+        def kill(wait = true, signal = nil, cleanup: !signal, hard: false)
             tpid = pid
             return if !tpid # already dead
 
+            signal ||=
+                if hard
+                    "SIGKILL"
+                else
+                    "SIGINT"
+                end
+
             # Stop all tasks and disconnect the ports
-            if !signal
+            if cleanup
                 clean_shutdown = true
                 begin
                     each_task do |task|
@@ -1290,13 +1297,7 @@ module Orocos
             end
 
             expected_exit = nil
-            if clean_shutdown
-                expected_exit = signal = SIGNAL_NUMBERS['SIGINT']
-	    else
-                signal = SIGNAL_NUMBERS['SIGINT']
-            end
-
-            if signal 
+            if signal
                 if !expected_exit
                     Orocos.warn "sending #{signal} to #{name}"
                 end

--- a/lib/orocos/remote_processes/client.rb
+++ b/lib/orocos/remote_processes/client.rb
@@ -248,9 +248,9 @@ module Orocos
         #
         # The call does not block until the process has quit. You will have to
         # call #wait_termination to wait for the process end.
-        def stop(deployment_name, wait)
+        def stop(deployment_name, wait, cleanup: true, hard: false)
             socket.write(COMMAND_END)
-            Marshal.dump(deployment_name, socket)
+            Marshal.dump([deployment_name, cleanup, hard], socket)
             if !wait_for_ack
                 raise Failed, "failed to quit #{deployment_name}"
             end

--- a/lib/orocos/remote_processes/process.rb
+++ b/lib/orocos/remote_processes/process.rb
@@ -37,9 +37,11 @@ module Orocos
             process_client.name_service.get(task_name, process: self)
         end
 
-        # Stops the process
-        def kill(wait = true)
-            process_client.stop(name, wait)
+        # Cleanly stop the process
+        #
+        # @see kill!
+        def kill(wait = true, cleanup: true, hard: false)
+            process_client.stop(name, wait, cleanup: cleanup, hard: hard)
         end
 
         # Wait for the 

--- a/lib/orocos/remote_processes/server.rb
+++ b/lib/orocos/remote_processes/server.rb
@@ -298,11 +298,11 @@ module Orocos
                     socket.write Marshal.dump(e.message)
                 end
             elsif cmd_code == COMMAND_END
-                name = Marshal.load(socket)
+                name, cleanup, hard = Marshal.load(socket)
                 Server.debug "#{socket} requested end of #{name}"
-                if p = processes[name]
+                if (p = processes[name])
                     begin
-                        end_process(p)
+                        end_process(p, cleanup: cleanup, hard: hard)
                         socket.write(RET_YES)
                     rescue Interrupt
                         raise
@@ -379,8 +379,8 @@ module Orocos
             processes[name] = p
         end
 
-        def end_process(p)
-            p.kill(false)
+        def end_process(p, cleanup: true, hard: false)
+            p.kill(false, cleanup: cleanup, hard: hard)
         end
 
         def quit

--- a/lib/orocos/ruby_tasks/process.rb
+++ b/lib/orocos/ruby_tasks/process.rb
@@ -102,10 +102,8 @@ module Orocos
             end
         end
 
-        def kill(wait = true, status = ProcessManager::Status.new(:exit_code => 0))
-            deployed_tasks.each_value do |task|
-                task.dispose
-            end
+        def kill(_wait = true, status = ProcessManager::Status.new(exit_code: 0), **)
+            deployed_tasks.each_value(&:dispose)
             dead!(status)
         end
 


### PR DESCRIPTION
This is meant to allow Syskit to bypass the stop/cleanup state
handling in Process#kill. This actually is leading to many issues,
one of them being that RemoteProcess::Porcess#stop is blocking
(since it depends on how tasks will terminate)