### PR TITLE
feat: separate the different test targets

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -3,24 +3,40 @@ require "rake/testtask"
 require './lib/orocos/rake'
 
 
-Rake::TestTask.new(:test) do |t|
+Rake::TestTask.new("test:core") do |t|
     t.libs << "lib"
     t.libs << "."
     test_files = FileList['test/**/test_*.rb']
     test_files.exclude "test/standalone/**/*"
-    if !Orocos::Rake::USE_ROS
-        test_files.exclude 'test/ros/**'
-    end
+    test_files.exclude "test/async/**/*"
+    test_files.exclude "test/ros/**/*"
     t.test_files = test_files
     t.warning = false
 end
 
-Rake::TestTask.new(:test_standalone) do |t|
+Rake::TestTask.new("test:ros") do |t|
     t.libs << "lib"
     t.libs << "."
-    t.test_files = FileList['test/standalone/test_*.rb']
+    t.test_files = FileList["test/ros/**/test_*.rb"]
     t.warning = false
 end
+
+Rake::TestTask.new("test:async") do |t|
+    t.libs << "lib"
+    t.libs << "."
+    t.test_files = FileList['test/async/**/test_*.rb']
+    t.warning = false
+end
+
+Rake::TestTask.new("test:standalone") do |t|
+    t.libs << "lib"
+    t.libs << "."
+    t.test_files = FileList['test/standalone/**/test_*.rb']
+    t.warning = false
+end
+
+task "test" => ["test:core", "test:async", "test:standalone"]
+task "test" => "test:ros" unless Orocos::Rake::USE_ROS
 
 def build_orogen(name, options = Hash.new)
     parsed_options = Hash.new
@@ -109,7 +125,6 @@ end
 require 'yard/rake/yardoc_task'
 YARD::Rake::YardocTask.new
 
-task :test
 task :doc => :yard
 task :docs => :yard
 task :redoc => :yard


### PR DESCRIPTION
This will allow to run test:core in CI, since async is too fragile
for that