### PR TITLE
Use RUBY_DONT_SUBST to avoid breaking boost with defined open etc.

### DIFF
--- a/ext/rorocos/rblocking_call.h
+++ b/ext/rorocos/rblocking_call.h
@@ -6,6 +6,7 @@
 #include <boost/function.hpp>
 #include <boost/function_types/result_type.hpp>
 #include <boost/bind.hpp>
+#define RUBY_DONT_SUBST
 #include <ruby.h>
 #include <ruby/thread.h>
 #include <stdarg.h>

--- a/ext/rorocos/rorocos.hh
+++ b/ext/rorocos/rorocos.hh
@@ -7,6 +7,8 @@
 
 // !!! ruby.h must be included LAST. It defines macros that break
 // !!! omniORB code
+// !!! also breaks boost nowadays, so keep it from substituting
+#define RUBY_DONT_SUBST
 #include <ruby.h>
 
 //if RTT_VERSION_GTE is not defined by above includes (RTT versions below 2.9)


### PR DESCRIPTION
According to the comments, this has already been hit in conjunction with omniorb, but now boost defines some "open" methods as well, whose name then get replaced with a small bit of code. This has only been compile tested. Runtime effects may involve not calling ruby's file io functions.