### PR TITLE
feat: give control over the registration of tasks on the CORBA naming service

### DIFF
--- a/ext/rorocos/ruby_task_context.cc
+++ b/ext/rorocos/ruby_task_context.cc
@@ -38,7 +38,7 @@ struct LocalTaskContext : public RTT::TaskContext
     { return model_name; }
     void setModelName(std::string const& value)
     { model_name = value; }
-    
+
     LocalTaskContext(std::string const& name)
         : RTT::TaskContext(name, TaskCore::PreOperational)
         , _getModelName("getModelName", &LocalTaskContext::getModelName, this, RTT::ClientThread)
@@ -57,7 +57,7 @@ struct LocalTaskContext : public RTT::TaskContext
         _state.keepLastWrittenValue(false);
         _state.keepNextWrittenValue(true);
         ports()->addPort(_state);
-        
+
         _state.keepLastWrittenValue(true);
         _state.write(getTaskState());
     }
@@ -174,7 +174,7 @@ static void delete_local_task_context(RLocalTaskContext* rtask)
     local_task_context_dispose(rtask);
 }
 
-static VALUE local_task_context_new(VALUE klass, VALUE _name)
+static VALUE local_task_context_new(VALUE klass, VALUE _name, VALUE use_naming)
 {
     std::string name = StringValuePtr(_name);
     LocalTaskContext* ruby_task = new LocalTaskContext(name);
@@ -185,7 +185,7 @@ static VALUE local_task_context_new(VALUE klass, VALUE _name)
     RTT::corba::CorbaDispatcher::Instance(ruby_task->ports(), ORO_SCHED_OTHER, RTT::os::LowestPriority);
 #endif
 
-    RTT::corba::TaskContextServer::Create(ruby_task);
+    RTT::corba::TaskContextServer::Create(ruby_task, RTEST(use_naming));
 
     VALUE rlocal_task = Data_Wrap_Struct(cLocalTaskContext, 0, delete_local_task_context, new RLocalTaskContext(ruby_task));
     rb_obj_call_init(rlocal_task, 1, &_name);
@@ -449,7 +449,7 @@ void Orocos_init_ruby_task_context(VALUE mOrocos, VALUE cTaskContext, VALUE cOut
     VALUE mRubyTasks = rb_define_module_under(mOrocos, "RubyTasks");
     cRubyTaskContext = rb_define_class_under(mRubyTasks, "TaskContext", cTaskContext);
     cLocalTaskContext = rb_define_class_under(cRubyTaskContext, "LocalTaskContext", rb_cObject);
-    rb_define_singleton_method(cLocalTaskContext, "new", RUBY_METHOD_FUNC(local_task_context_new), 1);
+    rb_define_singleton_method(cLocalTaskContext, "new", RUBY_METHOD_FUNC(local_task_context_new), 2);
     rb_define_method(cLocalTaskContext, "dispose", RUBY_METHOD_FUNC(static_cast<VALUE(*)(VALUE)>(local_task_context_dispose)), 0);
     rb_define_method(cLocalTaskContext, "ior", RUBY_METHOD_FUNC(local_task_context_ior), 0);
     rb_define_method(cLocalTaskContext, "model_name=", RUBY_METHOD_FUNC(local_task_context_set_model_name), 1);

--- a/lib/orocos/process.rb
+++ b/lib/orocos/process.rb
@@ -1083,7 +1083,8 @@ module Orocos
             wait: nil,
             output: nil,
             gdb: nil, valgrind: nil,
-            name_service: Orocos::CORBA.name_service
+            name_service: Orocos::CORBA.name_service,
+            register_on_name_server: true
         )
 
             raise "#{name} is already running" if alive?
@@ -1189,6 +1190,10 @@ module Orocos
 
                 if output_file_name && valgrind
                     cmdline.unshift "--log-file=#{output_file_name}.valgrind"
+                end
+
+                unless register_on_name_server
+                    cmdline << "--register-on-name-server" << "0"
                 end
 
                 if cmdline_wrapper

--- a/lib/orocos/ruby_tasks/process.rb
+++ b/lib/orocos/ruby_tasks/process.rb
@@ -74,13 +74,15 @@ module Orocos
         # Deploys the tasks defined in {model} as ruby tasks
         #
         # @return [void]
-        def spawn(options = Hash.new)
+        def spawn(register_on_name_server: true, **options)
             model.task_activities.each do |deployed_task|
                 name = get_mapped_name(deployed_task.name)
                 Orocos.allow_blocking_calls do
                     deployed_tasks[name] =
-                        task_context_class.from_orogen_model(name,
-                                                             deployed_task.task_model)
+                        task_context_class.from_orogen_model(
+                            name, deployed_task.task_model,
+                            register_on_name_server: register_on_name_server
+                        )
                 end
             end
             @alive = true

--- a/lib/orocos/ruby_tasks/process_manager.rb
+++ b/lib/orocos/ruby_tasks/process_manager.rb
@@ -43,7 +43,11 @@ module Orocos
             loader.register_deployment_model(model)
         end
 
-        def start(name, deployment_name, name_mappings, options)
+        def start(
+            name, deployment_name, name_mappings,
+            prefix: nil, task_context_class: self.task_context_class,
+            register_on_name_server: true, **_
+        )
             model = if deployment_name.respond_to?(:to_str)
                         loader.deployment_model_from_name(deployment_name)
                     else deployment_name
@@ -52,14 +56,15 @@ module Orocos
                 raise ArgumentError, "#{name} is already started in #{self}"
             end
 
-            prefix_mappings = Orocos::ProcessBase.resolve_prefix(model, options.delete(:prefix))
+            prefix_mappings = Orocos::ProcessBase.resolve_prefix(model, prefix)
             name_mappings = prefix_mappings.merge(name_mappings)
 
-            task_context_class = options.fetch(:task_context_class, self.task_context_class)
-            ruby_deployment = Process.new(self, name, model,
-                                          task_context_class: task_context_class)
+            ruby_deployment = Process.new(
+                self, name, model,
+                task_context_class: task_context_class
+            )
             ruby_deployment.name_mappings = name_mappings
-            ruby_deployment.spawn
+            ruby_deployment.spawn(register_on_name_server: register_on_name_server)
             deployments[name] = ruby_deployment
         end
 

--- a/lib/orocos/ruby_tasks/remote_task_context.rb
+++ b/lib/orocos/ruby_tasks/remote_task_context.rb
@@ -11,9 +11,12 @@ module Orocos
         # {RubyTasks::TaskContext}
         class RemoteTaskContext < Orocos::TaskContext
             # Create a {RemoteTaskContext} based on its orogen model
-            def self.from_orogen_model(name, orogen_model)
+            def self.from_orogen_model(name, orogen_model, register_on_name_server: true)
                 ruby_task = TaskContext.from_orogen_model(name, orogen_model)
-                remote_task = new(ruby_task.ior, name: ruby_task.name, model: ruby_task.model)
+                remote_task = new(
+                    ruby_task.ior,
+                    name: ruby_task.name, model: ruby_task.model
+                )
                 remote_task.instance_variable_set(:@local_ruby_task, ruby_task)
                 remote_task
             end

--- a/lib/orocos/ruby_tasks/task_context.rb
+++ b/lib/orocos/ruby_tasks/task_context.rb
@@ -22,8 +22,8 @@ module Orocos
         # Creates a new local task context that fits the given oroGen model
         #
         # @return [TaskContext]
-        def self.from_orogen_model(name, orogen_model)
-            new(name, model: orogen_model)
+        def self.from_orogen_model(name, orogen_model, **options)
+            new(name, model: orogen_model, **options)
         end
 
         # Creates a new ruby task context with the given name
@@ -31,15 +31,17 @@ module Orocos
         # @param [String] name the task name
         # @return [TaskContext]
         def self.new(
-            name, project: OroGen::Spec::Project.new(Orocos.default_loader),
-            model: nil, **options, &block
+            name,
+            project: OroGen::Spec::Project.new(Orocos.default_loader),
+            model: nil, register_on_name_server: true,
+            **options, &block
         )
             if block && !model
                 model = OroGen::Spec::TaskContext.new(project, name)
                 model.instance_eval(&block)
             end
 
-            local_task = LocalTaskContext.new(name)
+            local_task = LocalTaskContext.new(name, register_on_name_server)
             local_task.model_name = model.name if model&.name
 
             remote_task = super(local_task.ior, name: name, model: model, **options)


### PR DESCRIPTION
Depends on:
- [ ] https://github.com/rock-core/tools-orogen/pull/14

Syskit itself does not need it anymore, and in tests it's arguably generating a lot of noise (registering/deregistering tasks on the name service).

The main driver is to allow parallel execution of unit tests, which works right now, but generates so many "name service rebinding" messages as to be useless.