### PR TITLE
feat: implement deployment of orogen task contexts in-process

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -122,7 +122,8 @@ namespace :setup do
     end
 end
 
-require 'yard/rake/yardoc_task'
+require "yard"
+require "yard/rake/yardoc_task"
 YARD::Rake::YardocTask.new
 
 task :doc => :yard

--- a/ext/rorocos/ruby_task_context.cc
+++ b/ext/rorocos/ruby_task_context.cc
@@ -230,6 +230,21 @@ static VALUE local_task_context_ior(VALUE _task)
     return rb_str_new(ior.c_str(), ior.length());
 }
 
+/* Explicitly execute a running local task's updateHook when it is running on a slave
+ * activity
+ *
+ * Does nothing when on another activity
+ *
+ * @return [void]
+ * @see make_slave
+ */
+static VALUE local_task_context_execute(VALUE _task)
+{
+    RTT::TaskContext& task = local_task_context(_task);
+    task.getActivity()->execute();
+    return Qnil;
+}
+
 /* Setup this local task to be explicitly triggered (e.g. for port-driven tasks)
  *
  * @return [void]
@@ -600,6 +615,7 @@ void Orocos_init_ruby_task_context(VALUE mOrocos, VALUE cTaskContext, VALUE cOut
     cLocalTaskContext = rb_define_class_under(mOrocos, "LocalTaskContext", rb_cObject);
     rb_define_method(cLocalTaskContext, "dispose", RUBY_METHOD_FUNC(local_task_context_dispose), 0);
     rb_define_method(cLocalTaskContext, "ior", RUBY_METHOD_FUNC(local_task_context_ior), 0);
+    rb_define_method(cLocalTaskContext, "execute", RUBY_METHOD_FUNC(local_task_context_execute), 0);
     rb_define_method(cLocalTaskContext, "make_triggered", RUBY_METHOD_FUNC(local_task_context_make_triggered), 0);
     rb_define_method(cLocalTaskContext, "make_periodic", RUBY_METHOD_FUNC(local_task_context_make_periodic), 1);
     rb_define_method(cLocalTaskContext, "make_fd_driven", RUBY_METHOD_FUNC(local_task_context_make_fd_driven), 0);

--- a/lib/orocos.rb
+++ b/lib/orocos.rb
@@ -18,7 +18,7 @@ rescue LoadError => e
     STDERR.puts "and try again"
     exit 1
 end
-    
+
 require 'typelib'
 require 'orocos/base'
 require 'orocos/default_loader'
@@ -55,6 +55,8 @@ require 'orocos/operations'
 require 'orocos/process'
 require 'orocos/corba'
 require 'orocos/mqueue'
+
+require 'orocos/component_loader'
 
 # Updated file layout for ruby tasks
 require 'orocos/ruby_tasks'

--- a/lib/orocos/component_loader.rb
+++ b/lib/orocos/component_loader.rb
@@ -1,0 +1,15 @@
+module Orocos
+    class ComponentLoader
+        def initialize(loader: Orocos.default_pkgconfig_loader)
+            @pkgconfig_loader = loader
+        end
+
+        # Make a task library's task types available for deployment
+        #
+        # @param [String] name the task library name (e.g. logger)
+        def load_task_library(name)
+            path = @pkgconfig_loader.task_library_path_from_name(name)
+            load_library(path)
+        end
+    end
+end

--- a/lib/orocos/component_loader.rb
+++ b/lib/orocos/component_loader.rb
@@ -1,5 +1,8 @@
 module Orocos
+    # Interface allowing to instanciate orogen-generated components in-process
     class ComponentLoader
+        attr_reader :pkgconfig_loader
+
         def initialize(loader: Orocos.default_pkgconfig_loader)
             @pkgconfig_loader = loader
         end

--- a/lib/orocos/ruby_tasks/task_context.rb
+++ b/lib/orocos/ruby_tasks/task_context.rb
@@ -8,7 +8,7 @@ module Orocos
         # Internal handler used to represent the local RTT::TaskContext object
         #
         # It is created from Ruby as it handles the RTT::TaskContext pointer
-        class LocalTaskContext
+        class LocalRubyTaskContext
             # [Orocos::TaskContext] the remote task
             attr_reader :remote_task
             # [String] the task name
@@ -41,7 +41,7 @@ module Orocos
                 model.instance_eval(&block)
             end
 
-            local_task = LocalTaskContext.new(name, register_on_name_server)
+            local_task = LocalRubyTaskContext.new(name, register_on_name_server)
             local_task.model_name = model.name if model&.name
 
             remote_task = super(local_task.ior, name: name, model: model, **options)

--- a/test/test_component_loader.rb
+++ b/test/test_component_loader.rb
@@ -1,0 +1,26 @@
+require 'orocos/test'
+
+module Orocos
+    describe ComponentLoader do
+        before do
+            @loader = Orocos::ComponentLoader.new
+        end
+
+        describe "create_local_task_context" do
+            it "raises if the component type does not exist" do
+                assert_raises(ArgumentError) do
+                    @loader.create_local_task_context("mylogger", "does_not_exist", false)
+                end
+            end
+        end
+
+        it "creates a dynamically loaded component" do
+            @loader.load_task_library "logger"
+            local_task_context = @loader.create_local_task_context(
+                "mylogger", "logger::Logger", false
+            )
+            tc = Orocos::TaskContext.new(local_task_context.ior)
+            assert_equal "mylogger", tc.name
+        end
+    end
+end


### PR DESCRIPTION
This PR adds the API necessary to deploy task contexts that have been developed using C++ and orogen. The entry point is ComponentLoader