### PR TITLE
feat: allow to globally make 'buffer' select the circular buffer type

### DIFF
--- a/ext/rorocos/rorocos.cc
+++ b/ext/rorocos/rorocos.cc
@@ -395,6 +395,33 @@ static VALUE port_connected_p(VALUE self)
     return result ? Qtrue : Qfalse;
 }
 
+static RTT::corba::CConnectionModel defaultBufferType = RTT::corba::CBuffer;
+
+static VALUE port_set_default_buffer_type(VALUE, VALUE type) {
+    VALUE conn_type = SYM2ID(type);
+    if (conn_type == rb_intern("fifo_buffer"))
+        defaultBufferType = RTT::corba::CBuffer;
+    else if (conn_type == rb_intern("circular_buffer"))
+        defaultBufferType = RTT::corba::CCircularBuffer;
+    else
+    {
+        VALUE obj_as_str = rb_funcall(type, rb_intern("inspect"), 0);
+        rb_raise(rb_eArgError, "invalid buffer type %s", StringValuePtr(obj_as_str));
+    }
+
+    return defaultBufferType;
+}
+
+static VALUE port_get_default_buffer_type(VALUE) {
+    if (defaultBufferType == RTT::corba::CBuffer)
+        return ID2SYM(rb_intern("fifo_buffer"));
+    else if (defaultBufferType == RTT::corba::CCircularBuffer)
+        return ID2SYM(rb_intern("circular_buffer"));
+
+    // should never happen
+    rb_raise(rb_eStandardError, "invalid internal state, default buffer type invalid");
+}
+
 static RTT::corba::CConnPolicy policyFromHash(VALUE options)
 {
     RTT::corba::CConnPolicy result = toCORBA(RTT::ConnPolicy());
@@ -403,6 +430,8 @@ static RTT::corba::CConnPolicy policyFromHash(VALUE options)
     if (conn_type == rb_intern("data"))
         result.type = RTT::corba::CData;
     else if (conn_type == rb_intern("buffer"))
+        result.type = defaultBufferType;
+    else if (conn_type == rb_intern("fifo_buffer"))
         result.type = RTT::corba::CBuffer;
     else if (conn_type == rb_intern("circular_buffer"))
         result.type = RTT::corba::CCircularBuffer;
@@ -675,6 +704,8 @@ extern "C" void Init_rorocos()
     rb_define_method(cTaskContext, "do_port", RUBY_METHOD_FUNC(task_context_do_port), 2);
     rb_define_method(cTaskContext, "do_port_names", RUBY_METHOD_FUNC(task_context_port_names), 0);
 
+    rb_define_singleton_method(cPort, "default_buffer_type=", RUBY_METHOD_FUNC(port_set_default_buffer_type), 1);
+    rb_define_singleton_method(cPort, "default_buffer_type", RUBY_METHOD_FUNC(port_get_default_buffer_type), 0);
     rb_define_method(cPort, "connected?", RUBY_METHOD_FUNC(port_connected_p), 0);
     rb_define_method(cPort, "do_disconnect_from", RUBY_METHOD_FUNC(do_port_disconnect_from), 1);
     rb_define_method(cPort, "do_disconnect_all", RUBY_METHOD_FUNC(do_port_disconnect_all), 0);

--- a/test/test_port.rb
+++ b/test/test_port.rb
@@ -28,6 +28,63 @@ describe Orocos::Port do
         end
     end
 
+    describe ".default_buffer_type" do
+        after do
+            Orocos::Port.default_buffer_type = :fifo_buffer
+        end
+
+        it "is initialized to fifo_buffer" do
+            assert_equal :fifo_buffer, Orocos::Port.default_buffer_type
+        end
+
+        it "can be changed to circular_buffer" do
+            Orocos::Port.default_buffer_type = :circular_buffer
+            assert_equal :circular_buffer, Orocos::Port.default_buffer_type
+        end
+
+        it "can be changed back to fifo_buffer" do
+            Orocos::Port.default_buffer_type = :circular_buffer
+            Orocos::Port.default_buffer_type = :fifo_buffer
+            assert_equal :fifo_buffer, Orocos::Port.default_buffer_type
+        end
+    end
+
+    describe "the 'buffer' connection type in connection policies" do
+        before do
+            @source_task = new_ruby_task_context("source")
+            @source_task.create_output_port "p", "/int32_t"
+            @sink_task = new_ruby_task_context("sink")
+            @sink_task.create_input_port "p", "/int32_t"
+        end
+
+        after do
+            Orocos::Port.default_buffer_type = :fifo_buffer
+        end
+
+        it "uses fifo_buffer by default" do
+            @source_task.p.connect_to @sink_task.p, type: :buffer, size: 2
+            @source_task.p.write 1
+            @source_task.p.write 2
+            @source_task.p.write 3
+
+            assert_equal 1, @sink_task.p.read_new
+            assert_equal 2, @sink_task.p.read_new
+            assert_nil @sink_task.p.read_new
+        end
+
+        it "uses circular_buffer if default_buffer_type has been changed" do
+            Orocos::Port.default_buffer_type = :circular_buffer
+            @source_task.p.connect_to @sink_task.p, type: :buffer, size: 2
+            @source_task.p.write 1
+            @source_task.p.write 2
+            @source_task.p.write 3
+
+            assert_equal 2, @sink_task.p.read_new
+            assert_equal 3, @sink_task.p.read_new
+            assert_nil @sink_task.p.read_new
+        end
+    end
+
     describe "handle_mq_transport" do
         attr_reader :port
         before do


### PR DESCRIPTION
This commit makes 'buffer' an alias for either 'fifo_buffer' (the old type) or 'circular_buffer' (the new one). An accessor, Port.default_buffer_type= allows to change the default.

'fifo_buffer' is retained as default for backward compatibility