### PR TITLE
Fetch name argument from other_options using `fetch` 

### DIFF
--- a/lib/orocos/ruby_tasks/task_context.rb
+++ b/lib/orocos/ruby_tasks/task_context.rb
@@ -58,7 +58,8 @@ module Orocos
             raise
         end
 
-        def initialize(ior, name: self.name, **other_options)
+        def initialize(ior, other_options)
+            name = other_options.fetch(:name, self.name)
             @local_ports = Hash.new
             @local_properties = Hash.new
             @local_attributes = Hash.new


### PR DESCRIPTION
(instead of named parameter)

This fixes an error which made using e.g. oroshell (but probably anything capable of introspecting orogen tasks from ruby) unusable in ruby 3.x.

**I have no idea if this is the right way to fix this**

With ruby 2.7 this fixes a warning:
```
/opt/workspace/tools/orocos.rb/lib/orocos/ruby_tasks/task_context.rb:45: warning: Using the last argument as keyword parameters is deprecated; maybe ** should be added to the call
/opt/workspace/tools/orocos.rb/lib/orocos/ruby_tasks/task_context.rb:61: warning: The called method `initialize' is defined here
```

With ruby 3.2 this fixes an error:
```
/opt/workspace/tools/orocos.rb/lib/orocos/ruby_tasks/task_context.rb:66:in `initialize': wrong number of arguments (given 2, expected 1) (ArgumentError)
	from /opt/workspace/tools/orocos.rb/lib/orocos/ruby_tasks/task_context.rb:50:in `new'
	from /opt/workspace/tools/orocos.rb/lib/orocos/ruby_tasks/task_context.rb:50:in `new'
	from /opt/workspace/tools/orocos.rb/lib/orocos/base.rb:304:in `initialize'
	from /opt/workspace/tools/orocos.rb/bin/oroshell:18:in `<main>'
```