### PR TITLE
chore: ensure conf hash keys are strings

### DIFF
--- a/lib/orocos/configurations.rb
+++ b/lib/orocos/configurations.rb
@@ -366,6 +366,11 @@ module Orocos
         #   otherwise
         # @see extract
         def add(name, conf, normalize: true, merge: true)
+            unless name.kind_of? String
+                raise ArgumentError,
+                      "section name must be a String, but it is a #{name.class}"
+            end
+
             if normalize
                 conf = normalize_conf(conf)
             end
@@ -589,6 +594,10 @@ module Orocos
         def normalize_conf_hash(hash, value_t) # :nodoc:
             result = Hash.new
             hash.each do |key, value|
+                unless key.kind_of? String
+                    raise ArgumentError, "#{key} must be a String, but it is #{key.class}"
+                end
+
                 begin
                     field_t = value_t[key]
                 rescue ArgumentError => e

--- a/test/test_configurations.rb
+++ b/test/test_configurations.rb
@@ -597,6 +597,36 @@ describe Orocos::TaskConfigurations do
             assert @conf.add 'does_not_already_exist', Hash['compound' => Hash['compound' => Hash['intg' => 20]]], merge: false
             assert_equal 20, @conf.conf('does_not_already_exist')['compound']['compound']['intg'].to_ruby
         end
+
+        it "raises if conf section name is not a String" do
+            assert_raises(ArgumentError) do
+                @conf.add :test_section, Hash.new
+            end
+        end
+
+        it "raises if conf has string keys in the first level" do
+            # HACK: make it behave like an utilrb Symbol, which responds to #to_str
+            first_level = flexmock(:fp)
+            first_level.should_receive(:to_str).and_return('fp')
+            e =
+                assert_raises(ArgumentError) do
+                    @conf.add "test_section", { first_level => 10 }
+                end
+            assert /must be a String, but it is/.match? e.message
+        end
+
+        it "raises if conf has string keys on inner level" do
+            # HACK: make it behave like an utilrb Symbol, which responds to #to_str
+            inner_level = flexmock(:str)
+            inner_level.should_receive(:to_str).and_return('str')
+
+            e =
+                assert_raises(ArgumentError) do
+                    @conf.add "test_section",
+                              { 'compound' => { 'compound' => { inner_level => 'aaa' } } }
+                end
+            assert /must be a String, but it is/.match? e.message
+        end
     end
 
     describe "apply_conf_on_typelib_value" do


### PR DESCRIPTION
Depends on:
- [ ] https://github.com/rock-core/bundles-common_models/pull/54
- [ ] https://github.com/rock-core/tools-syskit/pull/555

this is a constraint not enforced anywhere and
syskit test harness stub api could be used to
stub confs with symbols as key. Leading to
unfaithful tests
